### PR TITLE
Pass through string handling when adapter not set.

### DIFF
--- a/phalcon/config/adapter/grouped.zep
+++ b/phalcon/config/adapter/grouped.zep
@@ -83,6 +83,11 @@ class Grouped extends Config
 
 			// Set to default adapter if passed as string
 			if typeof configName === "string" {
+				if defaultAdapter === null {
+					this->_merge(Factory::load(configName));
+					continue;
+				}
+
 				let configInstance = ["filePath" : configName, "adapter" : defaultAdapter];
 			} elseif !isset configInstance["adapter"] {
 				let configInstance["adapter"] = defaultAdapter;


### PR DESCRIPTION
Looking at the code for Config\Factory I can see that if it's given a string then it'll attempt to determine the adaptor from the extension. Grouped is able to take a list of filenames as strings and also uses Factory.

However it always converts those strings to arrays using the default adaptor! This means when it's passed down to factory that it doesn't behave quite as you'd expect if you were to imagine the array given the Grouped as an array of input parameters for Factory.

I don't think it's the end of the world but as an aggregate proxy for Factory Grouped is losing something in translation.

Keep in mind that: I haven't tested any of this including the original assertion. I don't really know zephir's syntax (if it even supports continue or === null). This wuld change the behaviour of the library.